### PR TITLE
Add info about CSP config

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,12 @@ class Location extends Resource
 ```
 
 ----
+## Deployment
 
+The map field uses a web worker that loads data from blob values, and if you have a strict Content-Security-Policy header (e.g. with `default 'none'`), you will need to give permission to load data via this method by adding a [`worker-src` directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/worker-src) to your CSP:
+
+    worker-src 'self' blob:;
+----
 ## Migration
 
 #### From 3.* to 4.*


### PR DESCRIPTION
I ran into a problem with the map field after updating from 3 to 4, as it apparently changed the way that map data is loaded to use a web worker in such a way that it was blocked by my CSP:

```
[Error] Refused to load blob:https://example.com/d658cb33-72a8-4342-a13a-f93f318e396c because it does not appear in the worker-src directive of the Content Security Policy.
[Error] SecurityError: The operation is insecure.
	Worker (nova-map-field:2:1074500)
	th (nova-map-field:2:1074500)
	(anonymous function) (nova-map-field:2:1186641)
	(anonymous function) (nova-map-field:2:2549904)
	Global Code (nova-map-field:2:2549908)
```
I use a strict CSP with `default 'none'` where I must explicitly enable all sources, and to solve this I needed to add this source to my CSP. This PR adds a note to that effect to the readme.